### PR TITLE
Django 1.11 Upgrade

### DIFF
--- a/templates/__overrides.html
+++ b/templates/__overrides.html
@@ -87,9 +87,9 @@
       </ul>
 
       <div class="foot_logos">
-        <a href="http://unl.edu" class="unl"><img src="/media/images/unl.png"/></a>
-        <a href="http://www.neh.gov/" class="neh"><img src="/media/images/logo_NEH.png"/></a>
-        <a href="http://www.nebraskahistory.org/index.shtml" class="nshs"><img src="/media/images/logo_nshs.png"/></a>
+        <a href="http://unl.edu" class="unl"><img src="{% static 'images/unl.png' %}"/></a>
+        <a href="http://www.neh.gov/" class="neh"><img src="{% static 'images/logo_NEH.png' %}"/></a>
+        <a href="http://www.nebraskahistory.org/index.shtml" class="nshs"><img src="{% static 'images/logo_nshs.png' %}"/></a>
       </div>
     </div>
   </div>

--- a/views.py
+++ b/views.py
@@ -1,45 +1,31 @@
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 
 def about(request):
     page_title = "About Nebraska Newspapers"
-    return render_to_response('about.html', 
-                            dictionary=locals(), 
-                            context_instance=RequestContext(request))
+    return render(request, 'about.html', locals())
 
 def access(request):
     page_title = "About Nebraska Newspapers"
-    return render_to_response('custom/access.html', 
-                            dictionary=locals(), 
-                            context_instance=RequestContext(request))
+    return render(request, 'custom/access.html', locals())
+
 def adding(request):
     page_title = "About Nebraska Newspapers"
-    return render_to_response('custom/adding.html', 
-                            dictionary=locals(), 
-                            context_instance=RequestContext(request))
+    return render(request, 'custom/adding.html', locals())
 
 def contact(request):
     page_title = "About Nebraska Newspapers"
-    return render_to_response('custom/contact.html', 
-                            dictionary=locals(), 
-                            context_instance=RequestContext(request))
+    return render(request, 'custom/contact.html', locals())
 
 def nnp(request):
     page_title = "About Nebraska Newspapers"
-    return render_to_response('custom/nnp.html', 
-                            dictionary=locals(), 
-                            context_instance=RequestContext(request))
+    return render(request, 'custom/nnp.html', locals())
 
 def ndnp(request):
     page_title = "About Nebraska Newspapers"
-    return render_to_response('custom/ndnp.html', 
-                            dictionary=locals(), 
-                            context_instance=RequestContext(request))
+    return render(request, 'custom/ndnp.html', locals())
 
 def publishing(request):
     page_title = "Publishing History"
-    return render_to_response('custom/publishing.html', 
-                            dictionary=locals(), 
-                            context_instance=RequestContext(request))
-
+    return render(request, 'custom/publishing.html', locals())
 


### PR DESCRIPTION
- Replace deprecated render_to_response with render
- Use Django URLs for static media